### PR TITLE
Make FirewallPolicyARN updatable

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-04-05T23:19:47Z"
+  build_date: "2024-04-21T20:32:54Z"
   build_hash: e8df4d5a4b86dea0e227786c2c3d213e5aeda97a
   go_version: go1.21.0
   version: v0.33.0-dirty
@@ -7,7 +7,7 @@ api_directory_checksum: 0717b34f140ececc64bf073425f985f1c1698fac
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: ab9c21cbbefe0cb0a7764cc1c59d34acc17286cb
+  file_checksum: 5e33d9a2f8ee7823669f2e7185f98985a1e4a98a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-04-05T20:51:42Z"
+  build_date: "2024-04-05T23:19:47Z"
   build_hash: e8df4d5a4b86dea0e227786c2c3d213e5aeda97a
   go_version: go1.21.0
   version: v0.33.0-dirty

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-03-29T14:35:08Z"
+  build_date: "2024-04-05T20:51:42Z"
   build_hash: e8df4d5a4b86dea0e227786c2c3d213e5aeda97a
-  go_version: go1.22.0
-  version: v0.33.0
+  go_version: go1.21.0
+  version: v0.33.0-dirty
 api_directory_checksum: 0717b34f140ececc64bf073425f985f1c1698fac
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 26b59b24fabc03276e52110a318f0b227b9fe45f
+  file_checksum: ab9c21cbbefe0cb0a7764cc1c59d34acc17286cb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -20,10 +20,14 @@ resources:
         in:
         - READY
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(a, b)
       sdk_delete_post_request:
         template_path: common/sdk_delete_post_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: common/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateFirewall
   FirewallPolicy:
     exceptions:
       terminal_codes:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -8,6 +8,9 @@ resources:
     fields:
       FirewallName: 
         is_primary_key: true
+      SubnetMappings:
+        compare:
+          is_ignored: true
     exceptions:
       terminal_codes:
       - InvalidRequestException
@@ -21,7 +24,7 @@ resources:
         - READY
     hooks:
       delta_pre_compare:
-        code: customPreCompare(a, b)
+        code: customPreCompare(delta, a, b)
       sdk_delete_post_request:
         template_path: common/sdk_delete_post_request.go.tpl
       sdk_read_one_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -20,10 +20,14 @@ resources:
         in:
         - READY
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(a, b)
       sdk_delete_post_request:
         template_path: common/sdk_delete_post_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: common/sdk_read_one_post_set_output.go.tpl
+    update_operation:
+      custom_method_name: customUpdateFirewall
   FirewallPolicy:
     exceptions:
       terminal_codes:

--- a/generator.yaml
+++ b/generator.yaml
@@ -8,6 +8,9 @@ resources:
     fields:
       FirewallName: 
         is_primary_key: true
+      SubnetMappings:
+        compare:
+          is_ignored: true
     exceptions:
       terminal_codes:
       - InvalidRequestException
@@ -21,7 +24,7 @@ resources:
         - READY
     hooks:
       delta_pre_compare:
-        code: customPreCompare(a, b)
+        code: customPreCompare(delta, a, b)
       sdk_delete_post_request:
         template_path: common/sdk_delete_post_request.go.tpl
       sdk_read_one_post_set_output:

--- a/pkg/resource/firewall/delta.go
+++ b/pkg/resource/firewall/delta.go
@@ -42,7 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	customPreCompare(a, b)
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.DeleteProtection, b.ko.Spec.DeleteProtection) {
 		delta.Add("Spec.DeleteProtection", a.ko.Spec.DeleteProtection, b.ko.Spec.DeleteProtection)
@@ -102,13 +102,6 @@ func newResourceDelta(
 	} else if a.ko.Spec.SubnetChangeProtection != nil && b.ko.Spec.SubnetChangeProtection != nil {
 		if *a.ko.Spec.SubnetChangeProtection != *b.ko.Spec.SubnetChangeProtection {
 			delta.Add("Spec.SubnetChangeProtection", a.ko.Spec.SubnetChangeProtection, b.ko.Spec.SubnetChangeProtection)
-		}
-	}
-	if len(a.ko.Spec.SubnetMappings) != len(b.ko.Spec.SubnetMappings) {
-		delta.Add("Spec.SubnetMappings", a.ko.Spec.SubnetMappings, b.ko.Spec.SubnetMappings)
-	} else if len(a.ko.Spec.SubnetMappings) > 0 {
-		if !reflect.DeepEqual(a.ko.Spec.SubnetMappings, b.ko.Spec.SubnetMappings) {
-			delta.Add("Spec.SubnetMappings", a.ko.Spec.SubnetMappings, b.ko.Spec.SubnetMappings)
 		}
 	}
 	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {

--- a/pkg/resource/firewall/delta.go
+++ b/pkg/resource/firewall/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.DeleteProtection, b.ko.Spec.DeleteProtection) {
 		delta.Add("Spec.DeleteProtection", a.ko.Spec.DeleteProtection, b.ko.Spec.DeleteProtection)

--- a/pkg/resource/firewall/sdk.go
+++ b/pkg/resource/firewall/sdk.go
@@ -548,7 +548,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	return nil, ackerr.NewTerminalError(ackerr.NotImplemented)
+	return rm.customUpdateFirewall(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 
 import pytest
-import time
 
 from pathlib import Path
 from typing import Dict, Any

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -12,9 +12,12 @@
 # permissions and limitations under the License.
 
 import pytest
-from typing import Dict, Any
-from pathlib import Path
+import time
 
+from pathlib import Path
+from typing import Dict, Any
+
+from acktest.k8s import resource as k8s
 from acktest.resources import load_resource_file
 
 SERVICE_NAME = "networkfirewall"
@@ -31,3 +34,36 @@ def load_networkfirewall_resource(resource_name: str, additional_replacements: D
     directory for the current service.
     """
     return load_resource_file(resource_directory, resource_name, additional_replacements=additional_replacements)
+
+def create_firewall_resource(
+    resource_plural,
+    resource_name,
+    spec_file,
+    replacements,
+    crd_group=CRD_GROUP,
+    namespace="default",
+):
+    resource_data = load_networkfirewall_resource(
+        spec_file,
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        crd_group, CRD_VERSION, resource_plural,
+        resource_name, namespace,
+    )
+    k8s.create_custom_resource(ref, resource_data)
+
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    return ref, cr
+
+def delete_firewall_resource(ref):
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+    except:
+        pass

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -19,7 +19,31 @@ import time
 import pytest
 import logging
 
+from acktest.resources import random_suffix_name
+from e2e import create_firewall_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+
 WAIT_AFTER_SECONDS = 10
+
+def create_simple_firewall_policy():
+    resource_name = random_suffix_name("fw-pol-ack-test", 24)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["FIREWALL_POLICY_NAME"] = resource_name
+    replacements["STATEFUL_DEFAULT_ACTION"] = "aws:drop_established"
+    replacements["RULE_ORDER"] = "STRICT_ORDER"
+    replacements["STREAM_EXCEPTION_POLICY"] = "DROP"
+    replacements["STATELESS_DEFAULT_ACTION"] = "aws:drop"
+    replacements["STATELESS_FRAG_DEFAULT_ACTION"] = "aws:forward_to_sfe"
+
+    ref, cr = create_firewall_resource(
+        "firewallpolicies",
+        resource_name,
+        "firewall_policy",
+        replacements,
+    )
+
+    return ref, cr
 
 class NetworkFirewallValidator:
     def __init__(self, networkfirewall_client):

--- a/test/e2e/tests/test_firewall.py
+++ b/test/e2e/tests/test_firewall.py
@@ -19,29 +19,25 @@ import time
 
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
-from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_networkfirewall_resource
+from e2e import service_marker, load_networkfirewall_resource, create_firewall_resource, delete_firewall_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
-from e2e.tests.helper import NetworkFirewallValidator
+from e2e.tests.helper import NetworkFirewallValidator, create_simple_firewall_policy
 
-RESOURCE_PLURAL = "firewalls"
-
-CREATE_WAIT_AFTER_SECONDS = 10
-UPDATE_WAIT_AFTER_SECONDS = 30
+UPDATE_WAIT_AFTER_SECONDS = 20
 # It takes really long for firewall to be created/deleted.
-TIMEOUT_SECONDS = 1000
+TIMEOUT_SECONDS = 1200
 
 @pytest.fixture
-def simple_firewall(request, simple_firewall_policy):
+def simple_firewall(request):
     fw_resource_name = random_suffix_name("firewall-ack-test", 24)
     resources = get_bootstrap_resources()
 
-    (_, policy_cr) = simple_firewall_policy
+    _, policy_cr = create_simple_firewall_policy()
     policy_status = policy_cr["status"]
     policy_resp = policy_status["firewallPolicyResponse"]
     policy_arn = policy_resp["firewallPolicyARN"]
     subnet_id = resources.SharedTestVPC.public_subnets.subnet_ids[0]
-
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements["FIREWALL_NAME"] = fw_resource_name
@@ -52,136 +48,71 @@ def simple_firewall(request, simple_firewall_policy):
     replacements["TRAFFIC_TYPE"] = "ALL"
     replacements["FIREWALL_POLICY_ARN"] = policy_arn
 
-    # Load Network Firewall CR
-    resource_data = load_networkfirewall_resource(
-        "firewall",
-        additional_replacements=replacements,
-    )
-
-    # Create k8s resource
-    ref = k8s.CustomResourceReference(
-        CRD_GROUP,
-        CRD_VERSION,
-        RESOURCE_PLURAL,
+    ref, cr = create_firewall_resource(
+        "firewalls",
         fw_resource_name,
-        namespace="default",
+        "firewall",
+        replacements,
     )
-    k8s.create_custom_resource(ref, resource_data)
 
-    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+    assert cr["status"]["firewall"]["firewallPolicyARN"] == policy_arn
 
-    # Get latest Network Firewall CR
-    cr = k8s.wait_resource_consumed_by_controller(ref)
+    # Create a new firewall policy
+    _, policy_cr = create_simple_firewall_policy()
+    policy_status = policy_cr["status"]
+    policy_resp = policy_status["firewallPolicyResponse"]
+    policy_arn = policy_resp["firewallPolicyARN"]
 
+    # Update existing firewall with new policy
+    updates = {
+        "spec": {
+            "firewallPolicyARN": policy_arn,
+        }
+    }
+    k8s.patch_custom_resource(ref, updates)
+    time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+    cr = k8s.get_resource(ref)
+
+    # Ensure policy ARN was updated in the firewall
     assert cr is not None
-    assert k8s.get_resource_exists(ref)
+    assert cr["status"]["firewall"]["firewallPolicyARN"] == policy_arn
 
     yield (ref, cr)
 
     # Try to delete, if doesn't already exist
-    try:
-        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
-        assert deleted
-    except:
-        pass
+    delete_firewall_resource(ref)
 
-@pytest.fixture
-def simple_firewall_policy(request):
-    resource_name = random_suffix_name("fw-pol-ack-test", 24)
-
-    replacements = REPLACEMENT_VALUES.copy()
-    replacements["FIREWALL_POLICY_NAME"] = resource_name
-    replacements["STATEFUL_DEFAULT_ACTION"] = "aws:drop_established"
-    replacements["RULE_ORDER"] = "STRICT_ORDER"
-    replacements["STREAM_EXCEPTION_POLICY"] = "DROP"
-    replacements["STATELESS_DEFAULT_ACTION"] = "aws:drop"
-    replacements["STATELESS_FRAG_DEFAULT_ACTION"] = "aws:forward_to_sfe"
-
-    # Load Firewall Policy CR
-    resource_data = load_networkfirewall_resource(
-        "firewall_policy",
-        additional_replacements=replacements,
-    )
-
-    # Create k8s resource
-    ref = k8s.CustomResourceReference(
-        CRD_GROUP,
-        CRD_VERSION,
-        "firewallpolicies",
-        resource_name,
-        namespace="default",
-    )
-    k8s.create_custom_resource(ref, resource_data)
-
-    time.sleep(CREATE_WAIT_AFTER_SECONDS)
-
-    # Get latest Firewall Policy CR
-    cr = k8s.wait_resource_consumed_by_controller(ref)
-
-    assert cr is not None
-    assert k8s.get_resource_exists(ref)
-
-    yield (ref, cr)
-
-    # Try to delete, if doesn't already exist
-    try:
-        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
-        assert deleted
-    except:
-        pass
-
-def create_adopted_resource_firewall(firwall_name):
+def create_adopted_resource_firewall(firewall_name):
     adopted_resource_name = random_suffix_name("firewall-ack-test-adopted-resource", 48)
     adopted_resource_fw_name = random_suffix_name("firewall-ack-test-adopted-resource-fw", 48)
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements["ADOPTED_FIREWALL_NAME"] = adopted_resource_fw_name
     replacements["ADOPTED_RESOURCE_NAME"] = adopted_resource_name
-    replacements["FIREWALL_NAME"] = firwall_name
+    replacements["FIREWALL_NAME"] = firewall_name
 
-    # Load Adopted Resource CR to adopt firewall
-    resource_data = load_networkfirewall_resource(
-        "adopted_resource_firewall",
-        additional_replacements=replacements,
-    )
-
-    # Create k8s resource
-    adopted_resource_ref = k8s.CustomResourceReference(
-        "services.k8s.aws",
-        "v1alpha1",
+    ref, cr = create_firewall_resource(
         "AdoptedResources",
         adopted_resource_name,
-        namespace="default",
+        "adopted_resource_firewall",
+        replacements,
+        "services.k8s.aws"
     )
-    k8s.create_custom_resource(adopted_resource_ref, resource_data)
-
-    time.sleep(6 * CREATE_WAIT_AFTER_SECONDS)
-
-    # Get latest AdoptedResource CR
-    adopted_resource_cr = k8s.wait_resource_consumed_by_controller(adopted_resource_ref)
-
-    assert adopted_resource_cr is not None
-    assert k8s.get_resource_exists(adopted_resource_ref)
 
     # Get Firewall CR generated by AdoptedResource
     fw_ref = k8s.CustomResourceReference(
-        CRD_GROUP,
-        CRD_VERSION,
-        RESOURCE_PLURAL,
+        "networkfirewall.services.k8s.aws",
+        "v1alpha1",
+        "firewalls",
         adopted_resource_fw_name,
         namespace="default",
     )
 
-    time.sleep(CREATE_WAIT_AFTER_SECONDS)
-
     fw_cr = k8s.wait_resource_consumed_by_controller(fw_ref)
 
     # Try to delete, if doesn't already exist
-    try:
-        _, deleted = k8s.delete_custom_resource(adopted_resource_ref, 3, 10)
-        assert deleted
-    except:
-        pass
+    delete_firewall_resource(ref)
 
     return (fw_ref, fw_cr)
 
@@ -193,17 +124,17 @@ class TestNetworkFirewall:
         (fw, cr) = simple_firewall
 
         firewall_config = cr["status"]["firewall"]
-        firwall_name = firewall_config["firewallName"]
+        firewall_name = firewall_config["firewallName"]
 
         networkfirewall_validator = NetworkFirewallValidator(networkfirewall_client)
         # Check Network Firewall comes to READY state
-        networkfirewall_validator.wait_for_firewall_creation_or_die(firwall_name, "READY", TIMEOUT_SECONDS)
+        networkfirewall_validator.wait_for_firewall_creation_or_die(firewall_name, "READY", TIMEOUT_SECONDS)
 
         # Adopt firewall using AdoptedResource CR
-        (fw_ref, fw_cr) = create_adopted_resource_firewall(firwall_name)
+        (fw_ref, fw_cr) = create_adopted_resource_firewall(firewall_name)
 
         # Delete k8s resource
         k8s.delete_custom_resource(fw_ref)
 
         # Check Firewall no longer exists in AWS
-        networkfirewall_validator.wait_for_firewall_deletion_or_die(firwall_name, TIMEOUT_SECONDS)
+        networkfirewall_validator.wait_for_firewall_deletion_or_die(firewall_name, TIMEOUT_SECONDS)

--- a/test/e2e/tests/test_firewall.py
+++ b/test/e2e/tests/test_firewall.py
@@ -24,7 +24,7 @@ from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.tests.helper import NetworkFirewallValidator, create_simple_firewall_policy
 
-UPDATE_WAIT_AFTER_SECONDS = 20
+UPDATE_WAIT_AFTER_SECONDS = 30
 # It takes really long for firewall to be created/deleted.
 TIMEOUT_SECONDS = 1200
 
@@ -33,7 +33,7 @@ def simple_firewall(request):
     fw_resource_name = random_suffix_name("firewall-ack-test", 24)
     resources = get_bootstrap_resources()
 
-    _, policy_cr = create_simple_firewall_policy()
+    policy_ref, policy_cr = create_simple_firewall_policy()
     policy_status = policy_cr["status"]
     policy_resp = policy_status["firewallPolicyResponse"]
     policy_arn = policy_resp["firewallPolicyARN"]
@@ -58,7 +58,7 @@ def simple_firewall(request):
     assert cr["status"]["firewall"]["firewallPolicyARN"] == policy_arn
 
     # Create a new firewall policy
-    _, policy_cr = create_simple_firewall_policy()
+    new_policy_ref, policy_cr = create_simple_firewall_policy()
     policy_status = policy_cr["status"]
     policy_resp = policy_status["firewallPolicyResponse"]
     policy_arn = policy_resp["firewallPolicyARN"]
@@ -81,6 +81,8 @@ def simple_firewall(request):
     yield (ref, cr)
 
     # Try to delete, if doesn't already exist
+    delete_firewall_resource(policy_ref)
+    delete_firewall_resource(new_policy_ref)
     delete_firewall_resource(ref)
 
 def create_adopted_resource_firewall(firewall_name):


### PR DESCRIPTION
**Description of changes**
The FirewallPolicyARN on the Firewall resource can be updatable through the `AssociateFirewallPolicy` API. This is something we're doing with our own local copy of this repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
